### PR TITLE
fix: resolve <leader>D conflict and improve DAP/neotest keymaps

### DIFF
--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -24,7 +24,7 @@ autocmd("LspAttach", {
 		map("n", "<leader>wl", function()
 			print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
 		end, "List workspace folders")
-		map("n", "<leader>D", vim.lsp.buf.type_definition, "Type definition")
+		map("n", "gy", vim.lsp.buf.type_definition, "Go to type definition")
 		map("n", "<leader>rn", vim.lsp.buf.rename, "Rename")
 		map("i", "<C-s>", vim.lsp.buf.signature_help, "Signature help")
 

--- a/lua/plugins/dap.lua
+++ b/lua/plugins/dap.lua
@@ -43,8 +43,10 @@ return {
 		},
 		config = function()
 			local dap = require("dap")
+			local wk = require("which-key")
 
-			dap.configurations.go = {
+			-- append extra go configs on top of what dap-go sets up
+			vim.list_extend(dap.configurations.go or {}, {
 				{
 					type = "go",
 					name = "Debug main",
@@ -61,38 +63,44 @@ return {
 						return vim.split(args, " ")
 					end,
 				},
-			}
+			})
+
+			-- register <leader>D as a named group so which-key shows it
+			wk.add({ { "<leader>D", group = "Debug" } })
 
 			-- breakpoints
-			vim.keymap.set("n", "<leader>Db", dap.toggle_breakpoint, { desc = "[D]ebug toggle [b]reakpoint" })
+			vim.keymap.set("n", "<leader>Db", dap.toggle_breakpoint, { desc = "Toggle breakpoint" })
 			vim.keymap.set("n", "<leader>DB", function()
 				dap.set_breakpoint(vim.fn.input("Condition: "))
-			end, { desc = "[D]ebug conditional [B]reakpoint" })
+			end, { desc = "Conditional breakpoint" })
 			vim.keymap.set("n", "<leader>Dl", function()
 				dap.set_breakpoint(nil, nil, vim.fn.input("Log message: "))
-			end, { desc = "[D]ebug [l]og point" })
+			end, { desc = "Log point" })
 
 			-- execution
-			vim.keymap.set("n", "<leader>Dc", dap.continue, { desc = "[D]ebug [c]ontinue" })
-			vim.keymap.set("n", "<leader>Ds", dap.step_over, { desc = "[D]ebug [s]tep over" })
-			vim.keymap.set("n", "<leader>Di", dap.step_into, { desc = "[D]ebug step [i]nto" })
-			vim.keymap.set("n", "<leader>Do", dap.step_out, { desc = "[D]ebug step [o]ut" })
-			vim.keymap.set("n", "<leader>DR", dap.restart, { desc = "[D]ebug [R]estart" })
-			vim.keymap.set("n", "<leader>Dr", dap.run_last, { desc = "[D]ebug [r]un last" })
-			vim.keymap.set("n", "<leader>Dq", dap.terminate, { desc = "[D]ebug [q]uit" })
+			vim.keymap.set("n", "<leader>Dc", dap.continue, { desc = "Continue" })
+			vim.keymap.set("n", "<leader>Ds", dap.step_over, { desc = "Step over" })
+			vim.keymap.set("n", "<leader>Di", dap.step_into, { desc = "Step into" })
+			vim.keymap.set("n", "<leader>Do", dap.step_out, { desc = "Step out" })
+			vim.keymap.set("n", "<leader>DR", dap.restart, { desc = "Restart" })
+			vim.keymap.set("n", "<leader>Dr", dap.run_last, { desc = "Run last" })
+			vim.keymap.set("n", "<leader>Dq", dap.terminate, { desc = "Quit" })
 
 			-- ui
 			vim.keymap.set("n", "<leader>Du", function()
 				require("dapui").toggle()
-			end, { desc = "[D]ebug [u]i toggle" })
+			end, { desc = "Toggle UI" })
+			vim.keymap.set({ "n", "v" }, "<leader>De", function()
+				require("dapui").eval()
+			end, { desc = "Eval expression" })
 
 			-- go-specific
 			vim.keymap.set("n", "<leader>Dt", function()
 				require("dap-go").debug_test()
-			end, { desc = "[D]ebug go [t]est" })
+			end, { desc = "Debug test (Go)" })
 			vim.keymap.set("n", "<leader>DT", function()
 				require("dap-go").debug_last_test()
-			end, { desc = "[D]ebug go last [T]est" })
+			end, { desc = "Debug last test (Go)" })
 		end,
 	},
 }

--- a/lua/plugins/neotest.lua
+++ b/lua/plugins/neotest.lua
@@ -8,7 +8,10 @@ return {
 		"nvim-neotest/neotest-go",
 	},
 	config = function()
-		require("neotest").setup({
+		local neotest = require("neotest")
+		local wk = require("which-key")
+
+		neotest.setup({
 			adapters = {
 				require("neotest-go")({
 					args = { "-v", "-count=1" },
@@ -16,28 +19,47 @@ return {
 			},
 		})
 
+		-- register <leader>n as a named group so which-key shows it
+		wk.add({ { "<leader>n", group = "Neotest" } })
+
 		vim.keymap.set("n", "<leader>nt", function()
-			require("neotest").run.run()
-		end, { desc = "[n]eotest run nearest [t]est" })
+			neotest.run.run()
+		end, { desc = "Run nearest test" })
+
+		vim.keymap.set("n", "<leader>nd", function()
+			neotest.run.run({ strategy = "dap" })
+		end, { desc = "Debug nearest test" })
 
 		vim.keymap.set("n", "<leader>nf", function()
-			require("neotest").run.run(vim.fn.expand("%"))
-		end, { desc = "[n]eotest run [f]ile" })
+			neotest.run.run(vim.fn.expand("%"))
+		end, { desc = "Run file" })
 
 		vim.keymap.set("n", "<leader>na", function()
-			require("neotest").run.run({ suite = true })
-		end, { desc = "[n]eotest run [a]ll" })
+			neotest.run.run({ suite = true })
+		end, { desc = "Run all" })
 
 		vim.keymap.set("n", "<leader>ns", function()
-			require("neotest").run.stop()
-		end, { desc = "[n]eotest [s]top" })
+			neotest.run.stop()
+		end, { desc = "Stop" })
 
 		vim.keymap.set("n", "<leader>no", function()
-			require("neotest").output_panel.toggle()
-		end, { desc = "[n]eotest [o]utput panel" })
+			neotest.output.open({ enter = true })
+		end, { desc = "Output (nearest)" })
+
+		vim.keymap.set("n", "<leader>nO", function()
+			neotest.output_panel.toggle()
+		end, { desc = "Output panel" })
 
 		vim.keymap.set("n", "<leader>nS", function()
-			require("neotest").summary.toggle()
-		end, { desc = "[n]eotest [S]ummary" })
+			neotest.summary.toggle()
+		end, { desc = "Summary" })
+
+		vim.keymap.set("n", "]n", function()
+			neotest.jump.next({ status = "failed" })
+		end, { desc = "Next failed test" })
+
+		vim.keymap.set("n", "[n", function()
+			neotest.jump.prev({ status = "failed" })
+		end, { desc = "Prev failed test" })
 	end,
 }


### PR DESCRIPTION
- move LSP type_definition off <leader>D (now gy) so it no longer shadows the debug prefix on every LSP-attached buffer
- register <leader>D (Debug) and <leader>n (Neotest) which-key groups
- append go dap configs via list_extend instead of overwriting the ones dap-go registers
- add DAP eval (<leader>De), debug-nearest-test (<leader>nd), focused test output, and failed-test navigation (]n/[n)